### PR TITLE
feat: complete undercover game engine and room gameplay panel

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -6,9 +6,9 @@
 
 ```text
 apps/               # 业务应用目录
-  ai/               # AI 助手配置占位
-  gamecore/         # 游戏会话协调占位
-  games/            # 游戏元数据占位
+  ai/               # AI 策略与助手配置
+  gamecore/         # 游戏会话模型、引擎基类与调度服务
+  games/            # 游戏元数据、词库与具体玩法实现
   rooms/            # 房间模型、业务服务、REST API、Consumers
   users/            # 自定义用户模型与认证 API
 config/             # Django 项目配置（ASGI/WSGI/Settings）
@@ -42,25 +42,29 @@ Dockerfile          # Docker 构建文件
 - 房间管理
   - `GET /api/rooms/`：分页查询房间列表，支持 `search`、`status`、`is_private` 参数。
   - `POST /api/rooms/`：创建房间，自动生成房间号并将房主加入。
-  - `GET /api/rooms/{id}/`：查看房间详情（含成员列表、房主标识、房态）。
+- `GET /api/rooms/{id}/`：查看房间详情（含成员列表、房主标识、房态与当前游戏会话）。
   - `POST /api/rooms/{id}/join/`、`POST /api/rooms/{id}/leave/`：加入/退出房间。
   - `POST /api/rooms/join-by-code/`：通过房号加入房间。
-  - `POST /api/rooms/{id}/start/`：房主发起游戏流程。
+- `POST /api/rooms/{id}/start/`：房主发起游戏流程，自动补齐 AI 玩家并启动“谁是卧底”引擎。
   - `DELETE /api/rooms/{id}/`：房主解散房间。
 - 健康检查：`GET /api/health/`。
 
-WebSocket 入口为 `ws://<host>/ws/rooms/<room_id>/?token=<jwt>`，仅允许房间成员建立连接，支持 `chat.message` 文本聊天与 `system.broadcast` 系统事件。
+WebSocket 入口为 `ws://<host>/ws/rooms/<room_id>/?token=<jwt>`，仅允许房间成员建立连接，支持 `system.sync` 快照、`system.broadcast` 系统事件、`chat.message` 聊天以及 `game.event` 游戏状态推送。
 
 ## 核心模块速览
 
 - `apps/rooms/services.py`
   - `create_room`：封装房间初始化、房主入座与系统广播。
   - `join_room` / `leave_room`：处理并发校验、席位分配、房主转移。
-  - `start_room` / `dissolve_room`：房主权限校验并通过 Channels 通知所有成员。
-- `apps/rooms/consumers.py`
-  - WebSocket 消息协议统一使用 `type` + `payload`，客户端连接后会收到 `system.sync` 房间快照。
-  - 支持 `chat.message` 文本消息、`system.broadcast` 系统通知与 `ping/pong` 心跳。
-- `apps/rooms/tests/`：使用 `pytest` + `pytest-django` 覆盖 REST & WS 核心流程，可作为新增功能的测试范例。
+  - `start_room`：自动补齐 AI 玩家、创建游戏会话并广播初始状态。
+  - `dissolve_room`：房主权限校验并通过 Channels 通知所有成员。
+- `apps/gamecore/engine.py`：定义 `BaseGameEngine`、`EnginePhase` 与 `GameEvent` 数据模型。
+- `apps/gamecore/services.py`：维护 `GameSession`，负责启动/更新引擎并通过 `game.event` 向前端推送状态。
+- `apps/games/models.py`：提供 `WordPair` 词库模型，支持按主题/难度随机抽词。
+- `apps/games/undercover/engine.py`：实现“谁是卧底”状态机，涵盖发言轮转、投票计票、平局重投、胜负判定及 AI 自动行为。
+- `apps/ai/services.py`：封装 AI 玩家昵称生成与简单策略（发言、投票决策）。
+- `apps/rooms/consumers.py`：WebSocket 协议统一使用 `type` + `payload`，支持聊天、系统广播、游戏事件与 `ping/pong` 心跳。
+- `apps/.../tests/`：`pytest` + `pytest-django` 覆盖 REST、WS 与游戏引擎核心流程，可作为新增功能的测试范例。
 
 ## 开发与测试
 
@@ -81,6 +85,7 @@ pytest
 
 - 需要 Redis 支撑多实例时，可使用 `docker compose up redis` 或本地安装 `redis-server` 后在 `.env` 中设置 `REDIS_URL=redis://127.0.0.1:6379/0`。
 - `python manage.py runserver` 已启用 ASGI，可直接用于 WS 调试；若需要压测或与前端联调，可改用 `daphne config.asgi:application --port 8000`。
-- `python manage.py shell_plus` 中可调用 `apps.rooms.services` 的函数进行手动验证，确保业务逻辑与广播一致。
+- `python manage.py shell_plus` 中可调用 `apps.rooms.services.start_room`、`apps.gamecore.services.handle_room_event` 模拟发言/投票流程。
+- `apps/games/models.WordPair` 提供词库维护能力，可用于导入或调试新的词条。
 
 > Tips：默认 `local` 配置关闭了全局权限校验，方便联调。生产环境请切换到 `config.settings.production` 并补充安全相关配置。

--- a/backend/apps/ai/__init__.py
+++ b/backend/apps/ai/__init__.py
@@ -1,1 +1,5 @@
 """AI integration application."""
+
+from .services import UndercoverAIStrategy, generate_ai_display_name
+
+__all__ = ["UndercoverAIStrategy", "generate_ai_display_name"]

--- a/backend/apps/ai/services.py
+++ b/backend/apps/ai/services.py
@@ -1,0 +1,104 @@
+"""Lightweight AI helpers used by the Undercover engine."""
+
+from __future__ import annotations
+
+import random
+from typing import Dict, Iterable, List
+
+
+AI_NAME_POOL = [
+    "星火分析师",
+    "逻辑黄鹂",
+    "飞驰信使",
+    "风趣段子手",
+    "冷静观察员",
+    "灵感画师",
+    "麦田诗人",
+    "暴风推理家",
+]
+
+STYLE_HINTS = {
+    "balanced": {
+        "prefix": ["我觉得", "简单聊聊", "我的理解是"],
+        "suffix": ["大家怎么看?", "也许有别的解读", "供参考"],
+    },
+    "rational": {
+        "prefix": ["从线索看", "根据词义", "综合考虑"],
+        "suffix": ["逻辑上比较合理", "欢迎补充", "这是我的判断"],
+    },
+    "humor": {
+        "prefix": ["哈哈", "讲个笑话", "别紧张"],
+        "suffix": ["别投我啊", "我先说到这", "别打我"]
+    },
+}
+
+
+def generate_ai_display_name(existing: Iterable[str]) -> str:
+    """Pick a unique-ish display name for auto-filled AI members."""
+
+    existing = set(existing)
+    candidates = AI_NAME_POOL[:]
+    random.shuffle(candidates)
+    for name in candidates:
+        if name not in existing:
+            return name
+    return f"AI玩家{random.randint(100, 999)}"
+
+
+class UndercoverAIStrategy:
+    """Heuristic based promptless AI fallback."""
+
+    def __init__(self, style: str = "balanced") -> None:
+        self.style = style if style in STYLE_HINTS else "balanced"
+
+    def _style_snippet(self) -> str:
+        hints = STYLE_HINTS[self.style]
+        return random.choice(hints["prefix"]), random.choice(hints["suffix"])
+
+    def generate_speech(
+        self,
+        *,
+        role: str,
+        word: str,
+        round_number: int,
+        history: List[Dict],
+    ) -> str:
+        prefix, suffix = self._style_snippet()
+        if not word:
+            body = "我这边空白，只能听听大家的方向"
+        elif role == "undercover":
+            body = f"这个词让我想到『{word}』，感觉可以往形象一点的方向聊"
+        else:
+            body = f"我的词比较倾向『{word}』，先抛个共识看看"
+        if round_number > 1 and history:
+            body += "，上一轮的讨论我还在回味"
+        return f"{prefix}{body}{suffix}"
+
+    def pick_vote(
+        self,
+        *,
+        voter_id: int,
+        alive_players: List[int],
+        assignments: Dict[str, Dict],
+        history: List[Dict],
+    ) -> int:
+        """Return a target seat id for the given voter."""
+
+        suspects = [pid for pid in alive_players if pid != voter_id]
+        if not suspects:
+            return voter_id
+        # Prefer players没有发言或在上一条 history 中
+        if history:
+            last = history[-1].get("player_id")
+            if last and last in suspects:
+                return last
+        # 保留一点倾向：卧底更易投向非卧底
+        voter_role = assignments.get(str(voter_id), {}).get("role")
+        civilians = [pid for pid in suspects if assignments.get(str(pid), {}).get("role") != "undercover"]
+        undercovers = [pid for pid in suspects if assignments.get(str(pid), {}).get("role") == "undercover"]
+        if voter_role == "undercover" and civilians:
+            return random.choice(civilians)
+        if voter_role != "undercover" and undercovers:
+            return random.choice(undercovers)
+        return random.choice(suspects)
+

--- a/backend/apps/gamecore/engine.py
+++ b/backend/apps/gamecore/engine.py
@@ -1,0 +1,93 @@
+"""Base classes shared by concrete game engines."""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Dict, Optional
+
+from django.utils import timezone
+
+from .models import GameSession
+
+
+class GameEngineError(Exception):
+    """Base exception for engine level failures."""
+
+
+class EnginePhase(str, Enum):
+    """Common lifecycle phases used by turn-based party games."""
+
+    PREPARING = "preparing"
+    SPEAKING = "speaking"
+    VOTING = "voting"
+    RESULT = "result"
+    ENDED = "ended"
+
+
+@dataclass
+class GameEvent:
+    """Normalized event payload consumed by engines."""
+
+    type: str
+    payload: Dict[str, Any]
+    actor_id: Optional[int] = None
+
+
+class BaseGameEngine:
+    """Minimal interface every game implementation must follow."""
+
+    engine_slug: str = "base"
+
+    def __init__(self, session: GameSession):
+        self.session = session
+        self.room = session.room
+        self.state: Dict[str, Any] = copy.deepcopy(session.state or {})
+        self.phase = EnginePhase(self.state.get("phase", session.current_phase or EnginePhase.PREPARING.value))
+
+    # ------------------------------------------------------------------
+    # Lifecycle hooks
+    # ------------------------------------------------------------------
+    def start_game(self) -> None:
+        """Initialize engine state. Must be implemented by subclasses."""
+
+        raise NotImplementedError
+
+    def handle_event(self, event: GameEvent) -> None:
+        """Process a user or system event and mutate engine state."""
+
+        raise NotImplementedError
+
+    def run_auto_actions(self) -> bool:
+        """Allow engines to enqueue automatic behaviors (AI turns, timers)."""
+
+        return False
+
+    # ------------------------------------------------------------------
+    # State helpers
+    # ------------------------------------------------------------------
+    def serialize_state(self) -> Dict[str, Any]:
+        """Return the authoritative internal state."""
+
+        data = copy.deepcopy(self.state)
+        data["phase"] = self.phase.value
+        return data
+
+    def get_public_state(self, *, for_user=None) -> Dict[str, Any]:  # pragma: no cover - interface shim
+        """Produce a sanitized state for external consumers."""
+
+        return self.serialize_state()
+
+    def to_session_fields(self) -> Dict[str, Any]:
+        """Map internal state to ``GameSession`` persistence fields."""
+
+        state = self.serialize_state()
+        return {
+            "state": state,
+            "current_phase": state.get("phase", EnginePhase.PREPARING.value),
+            "current_player_id": state.get("current_player_id"),
+            "round_number": state.get("round", self.session.round_number or 1),
+            "updated_at": timezone.now(),
+        }
+

--- a/backend/apps/gamecore/migrations/0003_extend_gamesession.py
+++ b/backend/apps/gamecore/migrations/0003_extend_gamesession.py
@@ -1,0 +1,65 @@
+"""Add engine metadata fields to GameSession."""
+
+from django.db import migrations, models
+from django.utils import timezone
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("gamecore", "0002_initial"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="gamesession",
+            old_name="created_at",
+            new_name="started_at",
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="current_phase",
+            field=models.CharField(default="preparing", max_length=32),
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="current_player_id",
+            field=models.PositiveIntegerField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="ended_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="engine",
+            field=models.CharField(default="undercover", max_length=64),
+            preserve_default=False,
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="round_number",
+            field=models.PositiveIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="state",
+            field=models.JSONField(blank=True, default=dict),
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="status",
+            field=models.CharField(
+                choices=[("active", "进行中"), ("completed", "已结束")],
+                default="active",
+                max_length=16,
+            ),
+        ),
+        migrations.AddField(
+            model_name="gamesession",
+            name="updated_at",
+            field=models.DateTimeField(auto_now=True, default=timezone.now),
+            preserve_default=False,
+        ),
+    ]

--- a/backend/apps/gamecore/models.py
+++ b/backend/apps/gamecore/models.py
@@ -1,15 +1,32 @@
-"""Core game coordination models placeholder."""
+"""Core game coordination models."""
+
+from __future__ import annotations
 
 from django.db import models
 
 
 class GameSession(models.Model):
+    """Persisted snapshot of a running game within a room."""
+
+    class SessionStatus(models.TextChoices):
+        ACTIVE = "active", "进行中"
+        COMPLETED = "completed", "已结束"
+
     room = models.ForeignKey("rooms.Room", related_name="sessions", on_delete=models.CASCADE)
-    created_at = models.DateTimeField(auto_now_add=True)
+    engine = models.CharField(max_length=64)
+    state = models.JSONField(default=dict, blank=True)
+    status = models.CharField(max_length=16, choices=SessionStatus.choices, default=SessionStatus.ACTIVE)
+    current_phase = models.CharField(max_length=32, default="preparing")
+    current_player_id = models.PositiveIntegerField(null=True, blank=True)
+    round_number = models.PositiveIntegerField(default=1)
+    started_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    ended_at = models.DateTimeField(null=True, blank=True)
 
     class Meta:
         verbose_name = "游戏会话"
         verbose_name_plural = "游戏会话"
+        ordering = ("-started_at",)
 
-    def __str__(self) -> str:
-        return f"Session for {self.room_id} at {self.created_at:%Y-%m-%d %H:%M}"
+    def __str__(self) -> str:  # pragma: no cover - convenience debug output
+        return f"{self.engine} session in room {self.room_id} ({self.get_status_display()})"

--- a/backend/apps/gamecore/services.py
+++ b/backend/apps/gamecore/services.py
@@ -1,0 +1,167 @@
+"""Coordinator utilities for running game engines within rooms."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from django.utils import timezone
+from django.utils.module_loading import import_string
+
+from apps.rooms.models import Room, RoomPlayer
+
+from .engine import BaseGameEngine, EnginePhase, GameEngineError, GameEvent
+from .models import GameSession
+
+LOGGER = logging.getLogger(__name__)
+
+ENGINE_REGISTRY: Dict[str, str] = {
+    "undercover": "apps.games.undercover.engine.UndercoverEngine",
+}
+
+
+class EngineNotRegistered(GameEngineError):
+    """Raised when requesting an unknown engine slug."""
+
+
+def _import_engine(engine_slug: str) -> type[BaseGameEngine]:
+    try:
+        dotted_path = ENGINE_REGISTRY[engine_slug]
+    except KeyError as exc:  # pragma: no cover - defensive guard
+        raise EngineNotRegistered(f"未注册的引擎: {engine_slug}") from exc
+    return import_string(dotted_path)
+
+
+def get_engine_for_session(session: GameSession) -> BaseGameEngine:
+    """Instantiate engine for a stored session."""
+
+    engine_cls = _import_engine(session.engine)
+    return engine_cls(session)
+
+
+def serialize_session_for_user(session: GameSession, *, user=None) -> Dict[str, Any]:
+    """Expose sanitized session snapshot for REST / WS consumers."""
+
+    engine = get_engine_for_session(session)
+    return {
+        "id": session.id,
+        "engine": session.engine,
+        "phase": session.current_phase,
+        "round": session.round_number,
+        "currentPlayerId": session.current_player_id,
+        "status": session.status,
+        "startedAt": session.started_at.isoformat(),
+        "updatedAt": session.updated_at.isoformat(),
+        "state": engine.get_public_state(for_user=user),
+    }
+
+
+def _broadcast_game_event(room: Room, payload: Dict[str, Any]) -> None:
+    """Send game updates to room websocket group."""
+
+    channel_layer = get_channel_layer()
+    if not channel_layer:  # pragma: no cover - channel-less env
+        LOGGER.debug("Channel layer missing, skip game broadcast")
+        return
+    async_to_sync(channel_layer.group_send)(
+        f"room_{room.id}",
+        {
+            "type": "game.event",
+            "payload": payload,
+        },
+    )
+
+
+def start_room_game(room: Room, *, engine_slug: str = "undercover") -> GameSession:
+    """Create a new session for the room and bootstrap engine state."""
+
+    room.sessions.filter(status=GameSession.SessionStatus.ACTIVE).update(
+        status=GameSession.SessionStatus.COMPLETED,
+        ended_at=timezone.now(),
+    )
+    session = GameSession.objects.create(room=room, engine=engine_slug)
+    engine = get_engine_for_session(session)
+    engine.start_game()
+    fields = engine.to_session_fields()
+    session.state = fields["state"]
+    session.current_phase = fields["current_phase"]
+    session.current_player_id = fields["current_player_id"]
+    session.round_number = fields["round_number"]
+    session.save(update_fields=[
+        "state",
+        "current_phase",
+        "current_player_id",
+        "round_number",
+        "updated_at",
+    ])
+    LOGGER.info("Room %s started game session %s", room.code, session.id)
+    public_session = serialize_session_for_user(session)
+    from apps.rooms.serializers import RoomDetailSerializer  # local import
+
+    room_snapshot = RoomDetailSerializer(room).data
+    room_snapshot["game_session"] = public_session
+    _broadcast_game_event(
+        room,
+        {
+            "event": "game_started",
+            "room": room_snapshot,
+            "session": public_session,
+        },
+    )
+    return session
+
+
+def handle_room_event(*, room: Room, actor: Optional[RoomPlayer], event_type: str, payload: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Push an event into the active engine and broadcast the result."""
+
+    payload = payload or {}
+    session = (
+        room.sessions.filter(status=GameSession.SessionStatus.ACTIVE)
+        .select_for_update()
+        .first()
+    )
+    if not session:
+        raise GameEngineError("房间尚未开始游戏")
+
+    engine = get_engine_for_session(session)
+    event = GameEvent(type=event_type, payload=payload, actor_id=actor.id if actor else None)
+    engine.handle_event(event)
+    changed = engine.run_auto_actions()
+    fields = engine.to_session_fields()
+    session.state = fields["state"]
+    session.current_phase = fields["current_phase"]
+    session.current_player_id = fields["current_player_id"]
+    session.round_number = fields["round_number"]
+    if engine.phase == EnginePhase.ENDED or fields["state"].get("winner"):
+        session.status = GameSession.SessionStatus.COMPLETED
+        session.ended_at = timezone.now()
+    session.save(update_fields=[
+        "state",
+        "current_phase",
+        "current_player_id",
+        "round_number",
+        "status",
+        "ended_at",
+        "updated_at",
+    ])
+
+    public_session = serialize_session_for_user(session)
+    from apps.rooms.serializers import RoomDetailSerializer  # local import to avoid circular
+
+    room_snapshot = RoomDetailSerializer(room).data
+    room_snapshot["game_session"] = public_session
+    _broadcast_game_event(
+        room,
+        {
+            "event": event_type,
+            "actor": actor.id if actor else None,
+            "session": public_session,
+            "room": room_snapshot,
+        },
+    )
+    if changed:
+        LOGGER.debug("Engine auto actions executed after %s", event_type)
+    return public_session
+

--- a/backend/apps/gamecore/tests/test_undercover_engine.py
+++ b/backend/apps/gamecore/tests/test_undercover_engine.py
@@ -1,0 +1,88 @@
+import random
+
+import pytest
+
+from apps.gamecore.engine import EnginePhase, GameEvent
+from apps.gamecore.models import GameSession
+from apps.gamecore.services import serialize_session_for_user
+from apps.games.models import WordPair
+from apps.games.undercover.engine import UndercoverEngine
+from apps.rooms.models import Room, RoomPlayer
+from apps.users.models import User
+
+
+@pytest.fixture
+def word_pair(db):
+    return WordPair.objects.create(
+        civilian_word="画笔",
+        undercover_word="钢笔",
+        topic="文具",
+        difficulty="easy",
+    )
+
+
+@pytest.fixture
+def room_with_players(db, word_pair):
+    owner = User.objects.create_user(username="owner", password="pass12345", email="o@example.com")
+    room = Room.objects.create(
+        name="卧底测试房",
+        code="TEST01",
+        owner=owner,
+        max_players=6,
+        config={"ai": {"auto_fill": False}},
+    )
+    RoomPlayer.objects.create(room=room, user=owner, seat_number=1, is_host=True, display_name="房主")
+    for index in range(2, 5):
+        user = User.objects.create_user(
+            username=f"player{index}", password="pass12345", email=f"p{index}@example.com"
+        )
+        RoomPlayer.objects.create(room=room, user=user, seat_number=index, display_name=f"玩家{index}")
+    return room
+
+
+@pytest.mark.django_db
+def test_undercover_engine_full_round(room_with_players, word_pair):
+    random.seed(7)
+    session = GameSession.objects.create(room=room_with_players, engine="undercover")
+    engine = UndercoverEngine(session)
+    engine.start_game()
+
+    assignments = engine.state["assignments"]
+    assert len(assignments) == room_with_players.players.filter(is_active=True).count()
+    undercover_id = next(int(pid) for pid, meta in assignments.items() if meta["role"] == "undercover")
+    civilians = [int(pid) for pid, meta in assignments.items() if meta["role"] != "undercover"]
+
+    engine.handle_event(GameEvent(type="ready", payload={}, actor_id=civilians[0]))
+    while engine.phase == EnginePhase.SPEAKING:
+        current_id = engine.state.get("current_player_id")
+        engine.handle_event(
+            GameEvent(type="submit_speech", payload={"content": "描述一下我的词"}, actor_id=current_id)
+        )
+
+    assert engine.phase == EnginePhase.VOTING
+
+    # 两个平民合力投出卧底
+    for voter in civilians:
+        engine.handle_event(GameEvent(type="submit_vote", payload={"target_id": undercover_id}, actor_id=voter))
+    # 卧底反投任意平民
+    engine.handle_event(
+        GameEvent(type="submit_vote", payload={"target_id": civilians[0]}, actor_id=undercover_id)
+    )
+
+    assert engine.phase == EnginePhase.RESULT
+    assert engine.state.get("winner") == "civilian"
+
+    session.state = engine.serialize_state()
+    session.current_phase = engine.phase.value
+    session.round_number = engine.state.get("round", 1)
+    session.current_player_id = engine.state.get("current_player_id")
+    session.save(update_fields=["state", "current_phase", "round_number", "current_player_id"])
+
+    viewer = room_with_players.players.filter(user__username="player2").first().user
+    public_state = serialize_session_for_user(session, user=viewer)
+    assignments_view = public_state["state"]["assignments"]
+    self_entry = next(item for item in assignments_view if item["playerId"] == viewer.room_memberships.first().id)
+    assert self_entry["word"] != ""
+    others = [item for item in assignments_view if item["playerId"] != self_entry["playerId"]]
+    assert all(entry["word"] != "" for entry in others)  # 结果阶段全部公开
+

--- a/backend/apps/games/admin.py
+++ b/backend/apps/games/admin.py
@@ -1,1 +1,18 @@
-"""Admin bindings placeholder for games app."""
+"""Admin bindings for games app."""
+
+from django.contrib import admin
+
+from .models import GameDefinition, WordPair
+
+
+@admin.register(GameDefinition)
+class GameDefinitionAdmin(admin.ModelAdmin):
+    list_display = ("name", "slug")
+    search_fields = ("name", "slug")
+
+
+@admin.register(WordPair)
+class WordPairAdmin(admin.ModelAdmin):
+    list_display = ("civilian_word", "undercover_word", "topic", "difficulty", "created_at")
+    list_filter = ("difficulty", "topic")
+    search_fields = ("civilian_word", "undercover_word", "topic")

--- a/backend/apps/games/migrations/0002_wordpair.py
+++ b/backend/apps/games/migrations/0002_wordpair.py
@@ -1,0 +1,37 @@
+"""Create word pair model for Undercover."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("games", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="WordPair",
+            fields=[
+                ("id", models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name="ID")),
+                ("topic", models.CharField(blank=True, max_length=120)),
+                ("civilian_word", models.CharField(max_length=60)),
+                ("undercover_word", models.CharField(max_length=60)),
+                (
+                    "difficulty",
+                    models.CharField(
+                        choices=[("easy", "简单"), ("medium", "适中"), ("hard", "困难")],
+                        default="easy",
+                        max_length=12,
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "verbose_name": "词库词对",
+                "verbose_name_plural": "词库词对",
+                "ordering": ("-created_at",),
+            },
+        ),
+    ]

--- a/backend/apps/games/models.py
+++ b/backend/apps/games/models.py
@@ -1,4 +1,9 @@
-"""Game definitions placeholder."""
+"""Game definitions and word bank models."""
+
+from __future__ import annotations
+
+import random
+from typing import Optional
 
 from django.db import models
 
@@ -14,3 +19,49 @@ class GameDefinition(models.Model):
 
     def __str__(self) -> str:
         return self.name
+
+
+class WordPairQuerySet(models.QuerySet):
+    def filter_by_preferences(self, *, topic: Optional[str] = None, difficulty: Optional[str] = None):
+        queryset = self
+        if topic:
+            queryset = queryset.filter(topic=topic)
+        if difficulty:
+            queryset = queryset.filter(difficulty=difficulty)
+        return queryset
+
+
+class WordPair(models.Model):
+    """Word pair collection used by Undercover game."""
+
+    DIFFICULTY_CHOICES = (
+        ("easy", "简单"),
+        ("medium", "适中"),
+        ("hard", "困难"),
+    )
+
+    topic = models.CharField(max_length=120, blank=True)
+    civilian_word = models.CharField(max_length=60)
+    undercover_word = models.CharField(max_length=60)
+    difficulty = models.CharField(max_length=12, choices=DIFFICULTY_CHOICES, default="easy")
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    objects = WordPairQuerySet.as_manager()
+
+    class Meta:
+        verbose_name = "词库词对"
+        verbose_name_plural = "词库词对"
+        ordering = ("-created_at",)
+
+    def __str__(self) -> str:  # pragma: no cover - human readable helper
+        return f"{self.civilian_word} / {self.undercover_word} ({self.topic or '无主题'})"
+
+    @classmethod
+    def pick_random(cls, *, topic: Optional[str] = None, difficulty: Optional[str] = None) -> "WordPair":
+        queryset = cls.objects.filter_by_preferences(topic=topic, difficulty=difficulty)
+        count = queryset.count()
+        if count == 0:
+            raise cls.DoesNotExist("未找到符合条件的词库词对")
+        index = random.randint(0, count - 1)
+        return queryset.all()[index]

--- a/backend/apps/games/undercover/__init__.py
+++ b/backend/apps/games/undercover/__init__.py
@@ -1,0 +1,5 @@
+"""谁是卧底游戏引擎入口."""
+
+from .engine import UndercoverEngine
+
+__all__ = ["UndercoverEngine"]

--- a/backend/apps/games/undercover/engine.py
+++ b/backend/apps/games/undercover/engine.py
@@ -1,0 +1,372 @@
+"""Concrete engine for the 谁是卧底 party game."""
+
+from __future__ import annotations
+
+import random
+from collections import Counter
+from typing import Any, Dict, List, Optional
+
+from django.db import transaction
+from django.utils import timezone
+
+from apps.ai.services import UndercoverAIStrategy
+from apps.gamecore.engine import BaseGameEngine, EnginePhase, GameEngineError
+from apps.rooms.models import RoomPlayer
+
+from ..models import WordPair
+
+
+class UndercoverEngine(BaseGameEngine):
+    """State machine for managing speaking, voting and result phases."""
+
+    engine_slug = "undercover"
+
+    def __init__(self, session):
+        super().__init__(session)
+        self.strategy = UndercoverAIStrategy(style=self._config().get("ai_style", "balanced"))
+
+    # ------------------------------------------------------------------
+    # Configuration helpers
+    # ------------------------------------------------------------------
+    def _config(self) -> Dict[str, Any]:
+        config = self.room.config or {}
+        return config.get("undercover", config.get("game", {}).get("undercover", {}))
+
+    def _word_preferences(self) -> Dict[str, Optional[str]]:
+        cfg = self._config()
+        return {
+            "topic": cfg.get("topic"),
+            "difficulty": cfg.get("difficulty"),
+        }
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+    def start_game(self) -> None:
+        players = list(
+            self.room.players.filter(is_active=True).select_for_update().order_by("seat_number")
+        )
+        if len(players) < 3:
+            raise GameEngineError("至少需要 3 名玩家才能开始游戏")
+
+        cfg = self._config()
+        undercover_count = max(1, int(cfg.get("undercover_count", 1)))
+        blank_count = max(0, int(cfg.get("blank_count", 0)))
+        if undercover_count + blank_count >= len(players):
+            raise GameEngineError("卧底与白板数量过多，请调整配置")
+
+        try:
+            pair = WordPair.pick_random(**self._word_preferences())
+        except WordPair.DoesNotExist as exc:  # pragma: no cover - validated in tests
+            raise GameEngineError("词库中暂无合适的词对，请先在后台配置") from exc
+
+        speaking_order = [player.id for player in players]
+        random.shuffle(speaking_order)
+
+        assignments: Dict[str, Dict[str, Any]] = {}
+        roles_pool: List[str] = (
+            ["undercover"] * undercover_count
+            + ["blank"] * blank_count
+            + ["civilian"] * (len(players) - undercover_count - blank_count)
+        )
+        random.shuffle(roles_pool)
+
+        with transaction.atomic():
+            updates: List[RoomPlayer] = []
+            for player, role in zip(players, roles_pool):
+                word = pair.undercover_word if role == "undercover" else pair.civilian_word
+                if role == "blank":
+                    word = ""
+                player.role = role
+                player.word = word
+                player.is_alive = True
+                updates.append(player)
+                assignments[str(player.id)] = {
+                    "player_id": player.id,
+                    "role": role,
+                    "word": word,
+                    "is_ai": player.is_ai,
+                    "display_name": player.resolved_display_name,
+                    "is_alive": True,
+                }
+            RoomPlayer.objects.bulk_update(updates, ["role", "word", "is_alive"])
+
+        self.phase = EnginePhase.PREPARING
+        self.state = {
+            "phase": self.phase.value,
+            "round": 1,
+            "current_player_id": None,
+            "players_order": speaking_order,
+            "assignments": assignments,
+            "alive_players": [pid for pid in speaking_order],
+            "speeches": [],
+            "votes": {},
+            "vote_round": 1,
+            "revote_candidates": [],
+            "history": [],
+            "word_pair": {
+                "topic": pair.topic,
+                "difficulty": pair.difficulty,
+            },
+        }
+        self._queue_reset()
+
+    # ------------------------------------------------------------------
+    # Event handling
+    # ------------------------------------------------------------------
+    def handle_event(self, event) -> None:
+        if event.type == "ready":
+            self._ensure_phase(EnginePhase.PREPARING)
+            self.phase = EnginePhase.SPEAKING
+            self.state["phase"] = self.phase.value
+            self._queue_reset()
+            return
+
+        if event.type == "submit_speech":
+            self._ensure_phase(EnginePhase.SPEAKING)
+            self._process_speech(event.actor_id, event.payload.get("content", ""))
+            return
+
+        if event.type == "submit_vote":
+            self._ensure_phase(EnginePhase.VOTING)
+            self._process_vote(event.actor_id, event.payload.get("target_id"))
+            return
+
+        if event.type == "force_result":
+            self.phase = EnginePhase.RESULT
+            self.state["phase"] = self.phase.value
+            return
+
+        raise GameEngineError(f"未知的事件类型: {event.type}")
+
+    # ------------------------------------------------------------------
+    # Automatic behaviors
+    # ------------------------------------------------------------------
+    def run_auto_actions(self) -> bool:
+        changed = False
+        while True:
+            if self.phase == EnginePhase.SPEAKING and self._current_is_ai():
+                speaker_id = self.state.get("current_player_id")
+                if speaker_id is None:
+                    break
+                assignment = self._assignment(speaker_id)
+                speech = self.strategy.generate_speech(
+                    role=assignment["role"],
+                    word=assignment["word"],
+                    round_number=self.state.get("round", 1),
+                    history=self.state.get("speeches", []),
+                )
+                self._process_speech(speaker_id, speech or "我先简单说两句。", is_ai=True)
+                changed = True
+                continue
+
+            if self.phase == EnginePhase.VOTING:
+                pending = [
+                    pid
+                    for pid in self._alive_player_ids()
+                    if self._assignment(pid)["is_ai"] and str(pid) not in self.state.get("votes", {})
+                ]
+                if pending:
+                    voter = pending[0]
+                    target = self.strategy.pick_vote(
+                        voter_id=voter,
+                        alive_players=self._eligible_vote_targets(),
+                        assignments=self.state["assignments"],
+                        history=self.state.get("speeches", []),
+                    )
+                    if target not in self._eligible_vote_targets() or target == voter:
+                        alternatives = [pid for pid in self._eligible_vote_targets() if pid != voter]
+                        target = random.choice(alternatives) if alternatives else voter
+                    self._process_vote(voter, target, is_ai=True)
+                    changed = True
+                    continue
+            break
+        return changed
+
+    # ------------------------------------------------------------------
+    # Serialization helpers
+    # ------------------------------------------------------------------
+    def get_public_state(self, *, for_user=None):
+        state = super().serialize_state()
+        viewer_player_id = None
+        if for_user:
+            membership = self.room.players.filter(user=for_user, is_active=True).first()
+            if membership:
+                viewer_player_id = membership.id
+
+        assignments_map = self.state.get("assignments", {})
+        public_assignments = []
+        for player_id_str, meta in assignments_map.items():
+            pid = int(player_id_str)
+            entry = {
+                "playerId": pid,
+                "displayName": meta["display_name"],
+                "isAi": meta["is_ai"],
+                "isAlive": meta.get("is_alive", True),
+            }
+            if viewer_player_id is None or pid == viewer_player_id or self.phase in {EnginePhase.RESULT, EnginePhase.ENDED}:
+                entry["role"] = meta.get("role")
+                entry["word"] = meta.get("word")
+            else:
+                entry["role"] = None
+                entry["word"] = None
+            public_assignments.append(entry)
+
+        state["assignments"] = public_assignments
+        votes = self.state.get("votes", {})
+        tally = Counter(votes.values()) if votes else Counter()
+        state["voteSummary"] = {
+            "submitted": len(votes),
+            "required": len(self._alive_player_ids()),
+            "tally": {int(k): v for k, v in tally.items()},
+        }
+        if viewer_player_id is not None and str(viewer_player_id) in votes:
+            state["voteSummary"]["selfTarget"] = votes[str(viewer_player_id)]
+
+        pair = self.state.get("word_pair", {})
+        state["word_pair"] = {
+            "topic": pair.get("topic"),
+            "difficulty": pair.get("difficulty"),
+        }
+        if viewer_player_id is not None and str(viewer_player_id) in assignments_map:
+            state["word_pair"]["selfWord"] = assignments_map[str(viewer_player_id)]["word"]
+
+        return state
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+    def _ensure_phase(self, phase: EnginePhase) -> None:
+        if self.phase != phase:
+            raise GameEngineError(f"当前阶段无法执行该操作（需要 {phase.value}，当前 {self.phase.value}）")
+
+    def _assignment(self, player_id: int) -> Dict[str, Any]:
+        try:
+            return self.state["assignments"][str(player_id)]
+        except KeyError as exc:  # pragma: no cover - defensive
+            raise GameEngineError("未知玩家") from exc
+
+    def _queue_reset(self):
+        alive = [pid for pid in self.state.get("players_order", []) if self._assignment(pid)["is_alive"]]
+        self.state["alive_players"] = alive
+        self.state["queue"] = list(alive)
+        self.state["current_player_id"] = alive[0] if alive else None
+
+    def _advance_queue(self):
+        queue = self.state.get("queue", [])
+        if queue:
+            queue.pop(0)
+        if queue:
+            self.state["current_player_id"] = queue[0]
+        else:
+            self.state["current_player_id"] = None
+
+    def _alive_player_ids(self) -> List[int]:
+        return [pid for pid in self.state.get("players_order", []) if self._assignment(pid)["is_alive"]]
+
+    def _current_is_ai(self) -> bool:
+        current = self.state.get("current_player_id")
+        if current is None:
+            return False
+        return bool(self._assignment(current)["is_ai"])
+
+    def _eligible_vote_targets(self) -> List[int]:
+        allowed = self.state.get("revote_candidates") or self._alive_player_ids()
+        return [int(pid) for pid in allowed]
+
+    def _process_speech(self, actor_id: Optional[int], content: str, *, is_ai: bool = False) -> None:
+        if actor_id is None:
+            raise GameEngineError("缺少发言玩家信息")
+        queue = self.state.get("queue", [])
+        if not queue or queue[0] != actor_id:
+            raise GameEngineError("当前并非该玩家的发言回合")
+        sanitized = content.strip() or ("AI" if is_ai else "")
+        if not sanitized:
+            raise GameEngineError("发言内容不能为空")
+        self.state.setdefault("speeches", []).append(
+            {
+                "player_id": actor_id,
+                "content": sanitized,
+                "is_ai": is_ai,
+                "timestamp": timezone.now().isoformat(),
+            }
+        )
+        self._advance_queue()
+        if self.state.get("current_player_id") is None:
+            self.phase = EnginePhase.VOTING
+            self.state["phase"] = self.phase.value
+            self.state["votes"] = {}
+            self.state["vote_round"] = self.state.get("vote_round", 1)
+            self.state["revote_candidates"] = []
+
+    def _process_vote(self, actor_id: Optional[int], target_id: Optional[int], *, is_ai: bool = False) -> None:
+        if actor_id is None:
+            raise GameEngineError("缺少投票玩家")
+        if target_id is None:
+            raise GameEngineError("需要指定投票目标")
+        if str(actor_id) in self.state.get("votes", {}):
+            raise GameEngineError("已完成投票，无法重复操作")
+        if actor_id not in self._alive_player_ids():
+            raise GameEngineError("被淘汰的玩家无法投票")
+        if target_id not in self._eligible_vote_targets():
+            raise GameEngineError("投票目标不合法")
+
+        self.state.setdefault("votes", {})[str(actor_id)] = int(target_id)
+        if len(self.state["votes"]) >= len(self._alive_player_ids()):
+            self._finalize_votes()
+
+    def _finalize_votes(self):
+        votes = self.state.get("votes", {})
+        tally = Counter(votes.values())
+        if not tally:
+            return
+        highest = max(tally.values())
+        leaders = [candidate for candidate, count in tally.items() if count == highest]
+        self.state.setdefault("history", []).append(
+            {
+                "round": self.state.get("round", 1),
+                "votes": {int(k): v for k, v in tally.items()},
+                "vote_round": self.state.get("vote_round", 1),
+            }
+        )
+        if len(leaders) > 1:
+            self.state["revote_candidates"] = leaders
+            self.state["votes"] = {}
+            self.state["vote_round"] = self.state.get("vote_round", 1) + 1
+            return
+
+        eliminated = leaders[0]
+        self._eliminate_player(eliminated)
+        winner = self._check_winner()
+        if winner:
+            self.phase = EnginePhase.RESULT
+            self.state["phase"] = self.phase.value
+            self.state["winner"] = winner
+            self.state["current_player_id"] = None
+            return
+
+        # Next round
+        self.state["round"] = self.state.get("round", 1) + 1
+        self.state["speeches"] = []
+        self.state["votes"] = {}
+        self.state["vote_round"] = 1
+        self.state["revote_candidates"] = []
+        self.phase = EnginePhase.SPEAKING
+        self.state["phase"] = self.phase.value
+        self._queue_reset()
+
+    def _eliminate_player(self, player_id: int) -> None:
+        assignment = self._assignment(player_id)
+        assignment["is_alive"] = False
+        RoomPlayer.objects.filter(pk=player_id).update(is_alive=False)
+
+    def _check_winner(self) -> Optional[str]:
+        alive_assignments = [self._assignment(pid) for pid in self._alive_player_ids()]
+        undercovers = [meta for meta in alive_assignments if meta["role"] == "undercover"]
+        civilians = [meta for meta in alive_assignments if meta["role"] != "undercover"]
+        if not undercovers:
+            return "civilian"
+        if len(undercovers) >= len(civilians):
+            return "undercover"
+        return None
+

--- a/doc/step3-progress.md
+++ b/doc/step3-progress.md
@@ -1,0 +1,43 @@
+# 步骤三交付总结：谁是卧底玩法与 AI 接入
+
+本文记录步骤三的核心成果，帮助新成员快速了解“谁是卧底”模式的实现方式与后续扩展方向。
+
+## 1. 玩法与会话框架
+
+- 引入 `apps/gamecore/engine.py` 定义通用 `BaseGameEngine`、`EnginePhase`、`GameEvent`。
+- `GameSession` 模型扩展引擎标识、状态 JSON、当前阶段/玩家、开始/结束时间，支持多次开局与历史保留。
+- `apps/gamecore/services.py` 负责启动/更新会话、广播 `game.event`，并提供引擎注册表机制方便新增玩法。
+
+## 2. “谁是卧底”引擎
+
+- `apps/games/models.WordPair` 作为词库来源，可按主题、难度随机抽词。
+- `apps/games/undercover/engine.UndercoverEngine` 完成身份发牌、发言轮转、投票计票、平票重投与胜负判定。
+- `apps/ai/services.UndercoverAIStrategy` 提供基础 AI 发言/投票策略与昵称生成，`rooms/services.start_room` 会根据房间配置自动补位。
+
+## 3. WebSocket 与房间服务
+
+- `apps/rooms/consumers.RoomConsumer` 新增 `game.event` 处理逻辑，将 `ready`、`submit_speech`、`submit_vote` 等事件传递给游戏引擎。
+- `apps/rooms/services.start_room` 在开局时补齐 AI、创建游戏会话并广播房间快照；`_serialize_room` 会附带 `game_session` 数据。
+
+## 4. 前端面板
+
+- `src/store/rooms.ts` 扩展 `gameSession` 状态、`sendGameEvent` 方法与 `game.event` 处理逻辑，收到广播后自动刷新房间详情。
+- `src/pages/RoomPage.vue` 重构为游戏面板：展示身份与词语、阶段提示、发言记录、投票按钮，并联动 WebSocket 触发事件。
+- `src/types/rooms.ts` 新增 `GameSessionSnapshot`、`UndercoverStateView` 等类型，确保交互逻辑具备类型约束。
+
+## 5. 测试与运行
+
+- `apps/gamecore/tests/test_undercover_engine.py` 覆盖完整一轮发言+投票流程；房间 REST/WS 测试同步适配新字段。
+- 建议执行：
+  ```bash
+  cd backend
+  pip install -r requirements/dev.txt
+  pytest
+  ```
+- 词库为空时请通过 Django shell 创建 `WordPair` 记录后再开启游戏。
+
+## 6. 后续建议
+
+- 在 `apps/gamecore.services.ENGINE_REGISTRY` 注册新的玩法引擎即可扩展更多游戏模式。
+- 将 `apps/ai/services.py` 的策略替换为真实大模型调用，并在前端展示 AI 行为的流式输出。
+- 引入倒计时、回合复盘、更多游戏内系统提示以及管理端词库维护工具。

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,6 @@
 # 前端应用（Vue 3 + Vite + Element Plus）
 
-该目录包含基于 Vue 3 + TypeScript 的前端工程。当前版本已实现登录/注册、房间大厅、房间内实时聊天等核心界面，与后端房间 API 与 WebSocket 完成打通。
+该目录包含基于 Vue 3 + TypeScript 的前端工程。当前版本已实现登录/注册、房间大厅、房间内实时聊天与“谁是卧底”游戏面板，与后端房间 API 与 WebSocket 完成打通。
 
 ## 主要特性
 
@@ -8,7 +8,7 @@
 - 集成 Element Plus，启用按需自动引入（unplugin-auto-import / unplugin-vue-components）。
 - 采用 Vue Router + Pinia 管理认证状态与房间大厅/房间内数据。
 - 封装房间 REST API、房号加入/创建表单以及基于 JWT 的 WebSocket 客户端。
-- 大厅支持搜索、状态筛选、房号加入、创建房间弹窗；房间页展示成员席位、连接状态和实时聊天。
+- 大厅支持搜索、状态筛选、房号加入、创建房间弹窗；房间页升级为游戏面板，展示身份词语、阶段提示、发言记录、投票按钮和实时聊天。
 
 ## 可用脚本
 
@@ -43,17 +43,17 @@ VITE_WS_BASE_URL=ws://localhost:8000/ws
 
 ## 房间模块速览
 
-- `src/store/rooms.ts`：管理大厅分页、房间详情、WebSocket 状态与消息列表，公开 `fetchRooms`、`joinRoom`、`leaveRoom`、`sendChatMessage` 等方法。
+- `src/store/rooms.ts`：管理大厅分页、房间详情、WebSocket 状态、消息列表与游戏会话，公开 `fetchRooms`、`joinRoom`、`leaveRoom`、`sendChat`、`sendGameEvent` 等方法。
 - `src/api/rooms.ts`：封装房间 REST 请求，包含房号加入、房间启动等接口。
-- `src/pages/lobby`、`src/pages/room`：分别对应大厅与房间界面，可在此扩展 UI 与交互。
+- `src/pages/lobby`、`src/pages/RoomPage.vue`：大厅列表与房间游戏面板，实现身份展示、发言/投票交互与聊天。
 - `src/services/gameSocket.ts`：统一维护 WebSocket 连接（包含 `connect`、`disconnect`、`getInstance`），并对外抛出监听器。
 
 ## 本地调试指南
 
 1. **配置身份**：在后端获取 JWT（参见根目录 README 中的功能验证指南），并通过登录页面输入用户名/密码登录。
 2. **大厅验证**：访问 `/lobby`，使用顶部搜索框筛选房间或通过“创建房间”弹窗快速创建新房间。
-3. **加入房间**：点击房间卡片或输入房号加入，房间页将展示成员席位与系统消息面板。
-4. **发送消息**：房间页输入框会通过 `rooms` Store 调用 WebSocket `chat.message`，在多个浏览器窗口间可看到实时广播。
+3. **加入房间**：点击房间卡片或输入房号加入，房间页将展示身份、阶段提示、发言记录与系统消息面板。
+4. **发起游戏**：房主点击“开始游戏”后，房间会自动补齐 AI 并进入准备阶段；可通过房间页的“通知开始发言”“提交发言”“投票”按钮触发 `game.event`，观察实时面板与聊天更新。
 
 ### 常见问题
 

--- a/frontend/src/components.d.ts
+++ b/frontend/src/components.d.ts
@@ -7,6 +7,7 @@ export {}
 /* prettier-ignore */
 declare module 'vue' {
   export interface GlobalComponents {
+    ElAlert: typeof import('element-plus/es')['ElAlert']
     ElButton: typeof import('element-plus/es')['ElButton']
     ElCard: typeof import('element-plus/es')['ElCard']
     ElCol: typeof import('element-plus/es')['ElCol']
@@ -16,16 +17,20 @@ declare module 'vue' {
     ElForm: typeof import('element-plus/es')['ElForm']
     ElFormItem: typeof import('element-plus/es')['ElFormItem']
     ElHeader: typeof import('element-plus/es')['ElHeader']
+    ElIcon: typeof import('element-plus/es')['ElIcon']
     ElInput: typeof import('element-plus/es')['ElInput']
     ElInputNumber: typeof import('element-plus/es')['ElInputNumber']
     ElMain: typeof import('element-plus/es')['ElMain']
     ElOption: typeof import('element-plus/es')['ElOption']
+    ElResult: typeof import('element-plus/es')['ElResult']
     ElRow: typeof import('element-plus/es')['ElRow']
     ElSelect: typeof import('element-plus/es')['ElSelect']
     ElSkeleton: typeof import('element-plus/es')['ElSkeleton']
     ElSpace: typeof import('element-plus/es')['ElSpace']
     ElSwitch: typeof import('element-plus/es')['ElSwitch']
     ElTag: typeof import('element-plus/es')['ElTag']
+    ElTimeline: typeof import('element-plus/es')['ElTimeline']
+    ElTimelineItem: typeof import('element-plus/es')['ElTimelineItem']
     RouterLink: typeof import('vue-router')['RouterLink']
     RouterView: typeof import('vue-router')['RouterView']
   }

--- a/frontend/src/types/rooms.ts
+++ b/frontend/src/types/rooms.ts
@@ -19,6 +19,56 @@ export interface RoomPlayer {
   isAlive: boolean;
 }
 
+export interface UndercoverAssignmentView {
+  playerId: number;
+  displayName: string;
+  isAi: boolean;
+  isAlive: boolean;
+  role: string | null;
+  word: string | null;
+}
+
+export interface UndercoverSpeech {
+  player_id: number;
+  content: string;
+  is_ai: boolean;
+  timestamp: string;
+}
+
+export interface UndercoverVoteSummary {
+  submitted: number;
+  required: number;
+  tally: Record<string, number>;
+  selfTarget?: number;
+}
+
+export interface UndercoverStateView {
+  phase: string;
+  round: number;
+  current_player_id: number | null;
+  assignments: UndercoverAssignmentView[];
+  speeches: UndercoverSpeech[];
+  voteSummary: UndercoverVoteSummary;
+  word_pair: {
+    topic?: string;
+    difficulty?: string;
+    selfWord?: string;
+  };
+  winner?: string;
+}
+
+export interface GameSessionSnapshot<TState = Record<string, unknown>> {
+  id: number;
+  engine: string;
+  phase: string;
+  round: number;
+  currentPlayerId: number | null;
+  status: string;
+  startedAt: string;
+  updatedAt: string;
+  state: TState;
+}
+
 export interface RoomListItem {
   id: number;
   name: string;
@@ -41,6 +91,7 @@ export interface RoomDetail extends RoomListItem {
   players: RoomPlayer[];
   isMember: boolean;
   isOwner: boolean;
+  gameSession: GameSessionSnapshot<UndercoverStateView> | null;
 }
 
 export interface ChatMessage {


### PR DESCRIPTION
## Summary
- implement the BaseGameEngine infrastructure and the complete Undercover engine with AI helpers and session serialization
- wire the engine into room services, WebSocket handling, and tests while adding the WordPair model and migrations
- rebuild the room page into a playable game panel and document stage three progress for backend, frontend, and project guides

## Testing
- `pip install -r requirements/dev.txt`
- `pytest`
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68df59a178088330b8db10501632bb70