### PR TITLE
Allow all origins for backend CORS

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -24,7 +24,9 @@ Dockerfile          # Docker 构建文件
 - `SECRET_KEY`：Django 密钥。
 - `DATABASE_URL`：默认指向 `mysql://ai_social_game:ai_social_game@db:3306/ai_social_game`。
 - `REDIS_URL`：Channels 使用的 Redis 连接。
-- `CORS_ALLOWED_ORIGINS`：允许的前端域名，默认 `http://localhost:5173`。
+- `CORS_ALLOW_ALL_ORIGINS`：是否放开 CORS 限制，默认 `True`。
+- `CORS_ALLOWED_ORIGINS`：当未放开限制时允许的前端域名列表，默认 `http://localhost:5173`。
+- `CORS_ALLOW_CREDENTIALS`：是否允许跨域携带认证信息，放开限制时默认 `False`，其他情况下默认 `True`。
 
 ## 关键依赖
 

--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -123,8 +123,15 @@ SIMPLE_JWT = {
     "AUTH_HEADER_TYPES": ("Bearer",),
 }
 
-CORS_ALLOW_CREDENTIALS = True
-CORS_ALLOWED_ORIGINS = env.list("CORS_ALLOWED_ORIGINS", default=["http://localhost:5173"])
+CORS_ALLOW_ALL_ORIGINS = env.bool("CORS_ALLOW_ALL_ORIGINS", default=True)
+
+if CORS_ALLOW_ALL_ORIGINS:
+    CORS_ALLOW_CREDENTIALS = env.bool("CORS_ALLOW_CREDENTIALS", default=False)
+else:
+    CORS_ALLOW_CREDENTIALS = env.bool("CORS_ALLOW_CREDENTIALS", default=True)
+    CORS_ALLOWED_ORIGINS = env.list(
+        "CORS_ALLOWED_ORIGINS", default=["http://localhost:5173"]
+    )
 
 CHANNEL_LAYERS = {
     "default": {


### PR DESCRIPTION
## Summary
- enable a configuration flag that allows the backend to default to accepting requests from any origin
- document the new CORS environment variables so local testing without a domain is straightforward

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e06ace88ac83309677f3f55d0b3a50