### PR TITLE
Allow frontend correlation ID header in CORS configuration

### DIFF
--- a/backend/config/settings/base.py
+++ b/backend/config/settings/base.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from datetime import timedelta
 
 import environ
+from corsheaders.defaults import default_headers
 
 BASE_DIR = Path(__file__).resolve().parent.parent.parent
 
@@ -132,6 +133,10 @@ else:
     CORS_ALLOWED_ORIGINS = env.list(
         "CORS_ALLOWED_ORIGINS", default=["http://localhost:5173"]
     )
+
+CORS_ALLOW_HEADERS = list(default_headers) + [
+    "x-request-id",
+]
 
 CHANNEL_LAYERS = {
     "default": {


### PR DESCRIPTION
## Summary
- import the default CORS header list and allow the X-Request-ID header used by the frontend
- ensure preflight requests succeed when the custom tracing header is sent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e06e58fa688330aaef7aa0e66f79c9