### PR TITLE
Configure Redis password support

### DIFF
--- a/backend/config/service_settings.py
+++ b/backend/config/service_settings.py
@@ -33,6 +33,7 @@ MYSQL_CONFIG: Final = {
 
 REDIS_CONFIG: Final = {
     "URL": _get_env("REDIS_URL", "redis://localhost:6379/0"),
+    "PASSWORD": _get_env("REDIS_PASSWORD", ""),
 }
 
 LLM_CONFIG: Final = {


### PR DESCRIPTION
## Summary
- add Redis password handling to the centralized service settings
- ensure the base Django settings reuse the service Redis credentials and inject passwords into URLs when needed

## Testing
- python -m compileall config (from backend directory)

------
https://chatgpt.com/codex/tasks/task_e_68e48ddfef8c833087f71297acba2b64